### PR TITLE
Update dependabot to group Python updates together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,7 @@ updates:
     schedule:
       # Check for updates to uv environment files every week
       interval: "weekly"
+    groups:
+      python-packages:
+        patterns:
+          - "*"

--- a/uv.lock
+++ b/uv.lock
@@ -2044,7 +2044,7 @@ wheels = [
 
 [[package]]
 name = "nviz"
-version = "0.0.post1.dev18"
+version = "0.0.post1.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "napari", extra = ["all"] },


### PR DESCRIPTION
This PR updates dependabot to group updates together so they may be applied in one PR when possible. Dependencies which don't align are normally updated individually.