### PR TITLE
Move to `macos-14` for pre-commit checks within GH Actions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   pre_commit_checks:
-    runs-on: ubuntu-22.04
+    runs-on: macos-14
     env:
       SYNAPSE_AUTH_TOKEN: ${{ secrets.SYNAPSE_AUTH_TOKEN }}
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   pre_commit_checks:
+    # use macos to run pre-commit checks to avoid
+    # challenges with linux headless display and
+    # code coverage related to printed stdout.
     runs-on: macos-14
     env:
       SYNAPSE_AUTH_TOKEN: ${{ secrets.SYNAPSE_AUTH_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
     -   id: yamllint
         exclude: pre-commit-config.yaml
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.11.7"
+    rev: "v0.11.8"
     hooks:
     -   id: ruff-format
     -   id: ruff


### PR DESCRIPTION
<!-- _modified from [EmbeddedArtistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)_
_referenced with modifications from [pycytominer](https://github.com/cytomining/pycytominer/blob/master/.github/PULL_REQUEST_TEMPLATE.md)_ -->

# Description

This PR comes as a result of difficulties with test coverage through GH Actions runners on Linux. We configure Linux within CI to run headlessly for Napari in order to effectively run tests that require a pseudo display. This causes challenges with printed output however and causes coverage to show surprising results. I don't believe we see this same issue within MacOS and it will likely provide a more consistent ability to create accurate coverage metrics.

Challenges are exhibited in #34 

## What kind of change(s) are included?

- [ ] Documentation (changes docs or other related content)
- [x] Bug fix (fixes an issue).
- [ ] Enhancement (adds functionality).
- [ ] Breaking change (these changes would cause existing functionality to not work as expected).

# Checklist

Please ensure that all boxes are checked before indicating that this pull request is ready for review.

- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] I have searched for existing content to ensure this is not a duplicate.
- [x] I have performed a self-review of these additions (including spelling, grammar, and related).
- [x] These changes pass all pre-commit checks.
- [x] I have added comments to my code to help provide understanding
- [ ] I have added a test which covers the code changes found within this PR
- [x] I have deleted all non-relevant text in this pull request template.
