### PR TITLE
Update GH Actions ubuntu version

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     # only build and deploy docs if the actor is not dependabot
     if: ${{ github.actor != 'dependabot[bot]' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         python_version: ["3.11", "3.12"]
-        os: [ubuntu-22.04, macos-14]
+        os: [ubuntu-24.04, macos-14]
     runs-on: ${{ matrix.os }}
     env:
       OS: ${{ matrix.os }}
@@ -57,7 +57,7 @@ jobs:
         with:
           python-version: ${{ matrix.python_version }}
       - name: Display configuration for Ubuntu
-        if: ${{ matrix.os == 'ubuntu-22.04' }}
+        if: ${{ matrix.os == 'ubuntu-24.04' }}
         uses: pyvista/setup-headless-display-action@v4
         with:
           qt: true


### PR DESCRIPTION
This PR updates ubuntu-latest to 24.04 (latest) for use within GH Actions.