### PR TITLE
Update pre-commit-lite conditions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,9 +34,10 @@ jobs:
         with:
           qt: true
       - uses: pre-commit/action@v3.0.1
+        id: pre_commit
       # run pre-commit ci lite for automated fixes
       - uses: pre-commit-ci/lite-action@v1.1.0
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() if: ${{ !cancelled() }}if: ${{ !cancelled() }} steps.pre_commit.outcome == 'failure' }}
   run_tests:
     strategy:
       matrix:


### PR DESCRIPTION
This PR updates the pre-commit-lite conditions so that only failures of pre-commit can trigger updates from pre-commit-lite. Without this change, updates may occur without pre-commit failures.